### PR TITLE
Revise default APIs and configuration

### DIFF
--- a/app/components/api-comparison/api-comparison.tsx
+++ b/app/components/api-comparison/api-comparison.tsx
@@ -1,23 +1,21 @@
 "use client";
 import { useState, useEffect } from "react";
 import { title } from '../../constants'
+import { generateAPIRequests } from "@/app/lib/nhl/constants";
 
 interface APIRequest {
-  endpoint: string
+  endpoint: string,
+  shortName?: string
 }
 
-interface APIResponse {
-  endpoint: string
+interface APIResponse extends APIRequest {
   responseTime: number
   httpStatusCode: number
   res: any
 }
 
 export default function APIComparison() {
-  const API_REQUESTS: APIRequest[] = [
-    { endpoint: "https://www.espn.com" },
-    { endpoint: "https://www.nhl.com" }
-  ]
+  const API_REQUESTS: APIRequest[] = generateAPIRequests()
   const [results, setResults] = useState<APIResponse[]>([]);
 
   useEffect(() => {
@@ -32,6 +30,7 @@ export default function APIComparison() {
 
         return {
           endpoint: url.endpoint,
+          shortName: url.shortName,
           responseTime: endTime - startTime,
           httpStatusCode: res.status,
           res,
@@ -55,9 +54,9 @@ export default function APIComparison() {
       <ul>
         {results.map((result, index) => (
           <li key={index}>
-            Response time is {result.responseTime.toFixed(2)}ms for{" "}
+            Response time is <strong>{result.responseTime.toFixed(2)} ms</strong> for{" "}
             <a href={result.endpoint} target="_blank" rel="noopener noreferrer">
-              {result.endpoint}
+              {result.shortName || result.endpoint}
             </a>
           </li>
         ))}

--- a/app/lib/nhl/constants.ts
+++ b/app/lib/nhl/constants.ts
@@ -1,0 +1,9 @@
+export const NHL_LIVE_GAME_URL = "https://statsapi.web.nhl.com/api/v1/game/2022030324/feed/live"
+export const NHL_SCHEDULE_URL = "https://statsapi.web.nhl.com/api/v1/schedule?startDate=2023-06-24&endDate=2023-06-24&hydrate=team,linescore,broadcasts(all),tickets,game(content(media(epg)),seriesSummary),radioBroadcasts,metadata,seriesSummary(series)&site=en_nhl&teamId=&gameType=&timecode="
+
+export const generateAPIRequests = () => {
+  return [
+    { endpoint: NHL_LIVE_GAME_URL, shortName: "NHL Live Game URL" },
+    { endpoint: NHL_SCHEDULE_URL, shortName: "NHL Schedule URL" }
+  ]
+}


### PR DESCRIPTION
This PR introduces two example API endpoints that are publicly available from the National Hockey League (NHL).